### PR TITLE
Add set2 support for HP Laptop MODEL 255 G9

### DIFF
--- a/muteled
+++ b/muteled
@@ -67,6 +67,7 @@ set2_models=(
 "15s-gy0"	# HP 15s-gy0501au
 "340S G7"	# HP 340S G7 Notebook PC
 "15-dw4"	# HP Laptop 15-dw4xxx
+"HP 255 15.6 inch G9 Notebook PC" # HP 255 15.6 inch G9 Notebook PC
 )
 
 # Group 2: set2 models


### PR DESCRIPTION
This adds my HP laptop model to the `set2_models` list.

The default/fallback commands did not work through the installed package, but the second command set works correctly on my laptop:

LED on:

`sudo hda-verb /dev/snd/hwC1D0 0x20 0x500 0x7 && sudo hda-verb /dev/snd/hwC1D0 0x20 0x400 0x1`

LED off:

`sudo hda-verb /dev/snd/hwC1D0 0x20 0x500 0x7 && sudo hda-verb /dev/snd/hwC1D0 0x20 0x400 0x0`

Install method tested: AUR

Output of product name command:

`HP 255 15.6 inch G9 Notebook PC`

After adding this model to `set2_models`, `/usr/bin/muteled` works correctly when muting and unmuting.

My product_name output is:

HP 255 15.6 inch G9 Notebook PC

It does not include a shorter model code like 15s-eq1, so I added the full product string to set2_models.